### PR TITLE
uid/gid script update for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dmypy.json
 # End of https://www.gitignore.io/api/python
 
 test/test-files/custom-dir-env-var
+/ops/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.6.0 (2019-Sep-13)
+
+Added OSX support
+
 ### 0.5.0 (2019-May-03)
 
 * support multi-line environment variables [#4](https://github.com/ai-traders/dojo/issues/4).
@@ -15,7 +19,7 @@
 
 * fix: added script to image_scripts which always setups `/run/user/<ID>`;
  add tests
-* image scripts: if olduid == newuid, do not run usermod or groupmod 
+* image scripts: if olduid == newuid, do not run usermod or groupmod
 
 ### 0.4.2 (2019-Apr-30)
 

--- a/Dojofile.build
+++ b/Dojofile.build
@@ -1,0 +1,4 @@
+DOJO_DOCKER_IMAGE=kudulab/golang-dojo:1.1.0
+DOJO_WORK_INNER="/dojo/work/src/gocd-cli"
+DOJO_DOCKER_OPTIONS="--security-opt seccomp:unconfined"
+DOJO_WORK_INNER="/dojo/work/src/dojo"

--- a/Idefile
+++ b/Idefile
@@ -1,4 +1,0 @@
-IDE_DRIVER=docker
-IDE_DOCKER_IMAGE="docker-registry.ai-traders.com/golang-ide:0.4.3"
-IDE_DOCKER_OPTIONS="--security-opt seccomp:unconfined"
-IDE_WORK_INNER="/ide/work/src/dojo"

--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ In any sensible organization, configuration management is used to provision the 
 The `Dojofile` is the *lock* file which allows to store this reference in source control. When you run `dojo <command>`, then the environment is fetched, just like a dependency manager would fetch all dependencies of the project.
 
 ## Development
-Run these commands in `ide` ([IDE](https://github.com/ai-traders/ide) is predecessor of Dojo):
+Run these commands in `dojo` (use previous version of dojo to build a next one):
 ```
 ./tasks deps
 ./tasks build

--- a/ci.gocd.yaml
+++ b/ci.gocd.yaml
@@ -164,5 +164,5 @@ pipelines:
                 - exec:
                     command: bash
                     arguments:
-                    - -c
-                    - ./tasks release_gh
+                      - -c
+                      - ./tasks release_gh

--- a/ci.gocd.yaml
+++ b/ci.gocd.yaml
@@ -25,16 +25,22 @@ pipelines:
                     destination:
               tasks:
                 - exec:
-                    command: ide
+                    command: dojo
                     arguments:
+                      - -c
+                      - Dojofile.build
                       - ./tasks deps
                 - exec:
-                    command: ide
+                    command: dojo
                     arguments:
+                      - -c
+                      - Dojofile.build
                       - ./tasks build
                 - exec:
-                    command: ide
+                    command: dojo
                     arguments:
+                      - -c
+                      - Dojofile.build
                       - ./tasks unit
       - e2e:
           clean_workspace: true

--- a/ci.gocd.yaml
+++ b/ci.gocd.yaml
@@ -5,8 +5,7 @@ pipelines:
     label_template: "${COUNT}-${git[:8]}"
     materials:
       git:
-        git: "git@git.ai-traders.com:dojo/dojo"
-        branch: master
+        type: configrepo
         blacklist:
         - "doc/**/*"
         - "**/*.md"
@@ -15,7 +14,8 @@ pipelines:
           clean_workspace: true
           jobs:
             build_unit:
-              elastic_profile_id: w.c1.m1024.e5
+              resources:
+                - docker
               artifacts:
                 - build:
                     source: bin/dojo_linux_amd64
@@ -46,7 +46,8 @@ pipelines:
           clean_workspace: true
           jobs:
             alpine:
-              elastic_profile_id: w.c1.m1024.e5
+              resources:
+                - docker
               tasks:
                 - fetch:
                     stage: build_unit
@@ -70,7 +71,8 @@ pipelines:
                     - -c
                     - ./tasks test_signals alpine
             ubuntu18:
-              elastic_profile_id: w.c1.m1024.e5
+              resources:
+                - docker
               tasks:
                 - fetch:
                     stage: build_unit
@@ -97,7 +99,8 @@ pipelines:
           clean_workspace: true
           jobs:
             linux:
-              elastic_profile_id: w.c1.m1024.e5
+              resources:
+                - docker
               tasks:
                 - fetch:
                     stage: build_unit
@@ -133,7 +136,8 @@ pipelines:
             type: manual
           jobs:
             code:
-              elastic_profile_id: w.c1.m1024.e5
+              resources:
+                - docker
               tasks:
                 - exec:
                     command: bash

--- a/image_scripts/src/etc_dojo.d/scripts/50-fix-uid-gid.sh
+++ b/image_scripts/src/etc_dojo.d/scripts/50-fix-uid-gid.sh
@@ -41,8 +41,8 @@ fi
 
 # use -n option which is the same as --numeric-uid-gid on Debian/Ubuntu,
 # but on Alpine, there is no --numeric-uid-gid option
-newuid=$(ls -n -d "${dojo_work}" | awk '{ print $3 }')
-newgid=$(ls -n -d "${dojo_work}" | awk '{ print $4 }')
+newuid=$(sudo -u "${owner_username}" ls -n -d "${dojo_work}" | awk '{ print $3 }')
+newgid=$(sudo -u "${owner_username}" ls -n -d "${dojo_work}" | awk '{ print $4 }')
 olduid=$(ls -n -d ${dojo_home} | awk '{ print $3 }')
 oldgid=$(ls -n -d ${dojo_home} | awk '{ print $4 }')
 

--- a/tasks
+++ b/tasks
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -Ee
 
-if [[ ! -f ./releaser ]];then
-  timeout 2 wget -O releaser http://http.archive.ai-traders.com/releaser/1.1.0/releaser || { echo "Cannot download releaser, ignoring"; rm -f ./releaser; }
+RELEASER_VERSION="2.1.0"
+RELEASER_FILE="ops/releaser-${RELEASER_VERSION}"
+
+mkdir -p ops
+if [[ ! -f $RELEASER_FILE ]];then
+  wget --quiet -O $RELEASER_FILE https://github.com/kudulab/releaser/releases/download/${RELEASER_VERSION}/releaser
 fi
-if [[ -f ./releaser ]];then
-  source ./releaser
-fi
+source $RELEASER_FILE
 
 function check_flavor {
   if [ -z "$1" ]; then
@@ -89,17 +91,36 @@ const DojoVersion = \"${next_version}\"
     release)
         version="$(releaser::get_last_version_from_whole_changelog ${changelog_file})"
         git tag "${version}"
-        git push origin "${version}"
+        git push kudulab "${version}"
         ;;
     release_gh)
         if [ ! -f bin/dojo_linux_amd64 ]; then echo "dojo_linux_amd64 binary does not exist"; exit 1; fi
         if [ ! -f bin/dojo_darwin_amd64 ]; then echo "dojo_darwin_amd64 binary does not exist"; exit 1; fi
         if [ -z "$GITHUB_TOKEN" ]; then echo "GITHUB_TOKEN is unset"; exit 1; fi
-        version="$(get_last_version_from_whole_changelog ${changelog_file})"
-        git remote add upstream git@github.com:ai-traders/dojo.git
-        git pull upstream master
-        git push --tags upstream master
-        ide --idefile Idefile.nodejs "sudo npm install --global release-it && release-it --verbose --increment=${version} --non-interactive"
+        releaser::prepare_github_release_bin
+        VERSION="$(releaser::get_last_version_from_whole_changelog ${changelog_file})"
+        GH_USER=kudulab
+
+        $GHRELEASE_BIN release \
+          --user $GH_USER \
+          --repo dojo \
+          --tag $VERSION \
+          --name $VERSION \
+          --pre-release
+
+        $GHRELEASE_BIN upload \
+          --user $GH_USER \
+          --repo dojo \
+          --tag $VERSION \
+          --name "dojo_linux_amd64" \
+          --file bin/dojo_linux_amd64
+
+        $GHRELEASE_BIN upload \
+          --user $GH_USER \
+          --repo dojo \
+          --tag $VERSION \
+          --name "dojo_darwin_amd64" \
+          --file bin/dojo_darwin_amd64
         ;;
     generate_release_notes)
         version=${2?version not set}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
-const DojoVersion = "0.5.0"
+const DojoVersion = "0.6.0"
 


### PR DESCRIPTION
This is a bit tricky solution but it will not break running the script on linux while it will fix the issue on macs.
We simply switch the current user to discover the uid/gid when running ls on the /dojo/work directory. This will have no affect on result on linux, but it will get the right value on mac.