### PR TITLE
Add TMPDIR to default blacklist for OSX support #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.6.1 (2019-Sep-16)
+
+Blacklist TMPDIR to improve OSX experience
+
 ### 0.6.0 (2019-Sep-13)
 
 Added OSX support

--- a/config.go
+++ b/config.go
@@ -362,7 +362,7 @@ func getDefaultConfig(configFile string) Config {
 		WorkDirOuter:       currentDirectory,
 		WorkDirInner:       "/dojo/work",
 		IdentityDirOuter:   currentUser.HomeDir,
-		BlacklistVariables: "BASH*,HOME,USERNAME,USER,LOGNAME,PATH,TERM,SHELL,MAIL,SUDO_*,WINDOWID,SSH_*,SESSION_*,GEM_HOME,GEM_PATH,GEM_ROOT,HOSTNAME,HOSTTYPE,IFS,PPID,PWD,OLDPWD,LC*",
+		BlacklistVariables: "BASH*,HOME,USERNAME,USER,LOGNAME,PATH,TERM,SHELL,MAIL,SUDO_*,WINDOWID,SSH_*,SESSION_*,GEM_HOME,GEM_PATH,GEM_ROOT,HOSTNAME,HOSTTYPE,IFS,PPID,PWD,OLDPWD,LC*,TMPDIR",
 		DockerComposeFile:  "docker-compose.yml",
 		ExitBehavior:       "abort",
 		PreserveEnvironmentToAllContainers: "true",

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
-const DojoVersion = "0.6.0"
+const DojoVersion = "0.6.1"
 


### PR DESCRIPTION
MacOSX has a weird TMPDIR which gets passed on to the docker environment and leads to problems with some applications (e.g. discovered in terraform and gocd).