### PR TITLE
[WIP] Dump logs before cleaning docker-compose containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.7.0 (2020-Jan-01)
+
+Docker-compose driver: print logs of non default docker containers. By default this will be done if any
+ of the containers (default or not) failed. This can be set by `--print-logs` commandline option
+ and by `DOJO_DOCKER_COMPOSE_PRINT_LOGS` Dojofile option.
+ Possible values: always, failure, never. [#12](https://github.com/kudulab/dojo/issues/12)
+
 ### 0.6.3 (2019-Sep-19)
 
 Fix homebrew formula to handle upgrades

--- a/Dojofile.e2e-alpine
+++ b/Dojofile.e2e-alpine
@@ -1,2 +1,2 @@
-DOJO_DOCKER_IMAGE="kudulab/inception-dojo:alpine-dind-0.1.1"
+DOJO_DOCKER_IMAGE="kudulab/inception-dojo:alpine-dind-0.1.2"
 DOJO_DOCKER_OPTIONS="--privileged"

--- a/Dojofile.e2e-ubuntu18
+++ b/Dojofile.e2e-ubuntu18
@@ -1,2 +1,2 @@
-DOJO_DOCKER_IMAGE="kudulab/inception-dojo:ubuntu18-dind-0.1.1"
+DOJO_DOCKER_IMAGE="kudulab/inception-dojo:ubuntu18-dind-0.1.2"
 DOJO_DOCKER_OPTIONS="--privileged"

--- a/README.md
+++ b/README.md
@@ -600,6 +600,8 @@ Usage of dojo <flags> [--] <CMD>:
     	Set to false if you want to force not interactive docker run
   -preserve-env-to-all string
 
+  -print-logs string
+        Decide when to print the logs of non-default containers. Possible values: always, failure (default), never. Only for driver: docker-compose
   -remove-containers string
     	Set to true if you want to not remove docker containers. Default: true
   -rm string

--- a/config_test.go
+++ b/config_test.go
@@ -120,6 +120,7 @@ func Test_getCLIConfig(t *testing.T) {
 		{[]string{"cmd", "-i=false"}, Config{Action:"", ConfigFile:"", Driver:"", Debug:"", Interactive:"false"}},
 		{[]string{"cmd", "--remove-containers=false"}, Config{RemoveContainers: "false"}},
 		{[]string{"cmd", "--rm=false"}, Config{RemoveContainers: "false"}},
+		{[]string{"cmd", "-print-logs=always"}, Config{PrintLogs:"always"}},
 	}
 
 	for _, currentTest := range flagTest {
@@ -285,6 +286,21 @@ func Test_verifyConfig_invalidDriver(t *testing.T) {
 	assert.Equal(t, "Invalid configuration, unsupported Driver: mydriver. Supported: docker, docker-compose", err.Error())
 }
 
+func Test_verifyConfig_invalidPrintLogs(t *testing.T) {
+	config := &Config{
+		Action: "run",
+		Driver: "docker-compose",
+		Debug: "true",
+		RemoveContainers: "true",
+		PreserveEnvironmentToAllContainers: "true",
+		PrintLogs: "bla",
+	}
+	logger := NewLogger("debug")
+	err := verifyConfig(logger, config)
+	assert.NotNil(t, err)
+	assert.Equal(t, "Invalid configuration, PrintLogs supported values are: always, failure, never. It was set to: bla", err.Error())
+}
+
 func Test_verifyConfig_driverShorthandDC(t *testing.T) {
 	dcFile := "/tmp/dojo-Test_verifyConfig_driverShorthandDC.yml"
 	config := &Config{
@@ -296,6 +312,7 @@ func Test_verifyConfig_driverShorthandDC(t *testing.T) {
 		DockerComposeFile: dcFile,
 		PreserveEnvironmentToAllContainers: "true",
 		ExitBehavior: "ignore",
+		PrintLogs: "never",
 	}
 	os.Create(dcFile)
 	logger := NewLogger("debug")
@@ -325,6 +342,7 @@ func Test_mapToConfig(t *testing.T) {
 	mymap["preserveEnvironmentToAllContainers"] = "false"
 	mymap["exitBehavior"] = "ignore"
 	mymap["test"] = "false"
+	mymap["printLogs"] = "always"
 	config := MapToConfig(mymap)
 	assert.Equal(t, "mydriver", config.Driver)
 	assert.Equal(t, "run", config.Action)

--- a/docker_compose_driver.go
+++ b/docker_compose_driver.go
@@ -399,7 +399,7 @@ func (dc DockerComposeDriver) HandleRun(mergedConfig Config, runID string, envSe
 	// * or it was stopped by a handle signal function, we expect all containers to be stopped (default container
 	// may be removed)
 
-	dc.Logger.Log("debug", fmt.Sprintf("Collecting information from other containers"))
+	dc.Logger.Log("debug", fmt.Sprintf("Collecting information from non default containers"))
 	containersNames := dc.getDCContainersNames(mergedConfig, runID)
 	containersInfos := dc.getNonDefaultContainersInfos(containersNames)
 	anyContainerFailed := checkIfAnyContainerFailed(containersInfos, exitStatus)
@@ -409,13 +409,13 @@ func (dc DockerComposeDriver) HandleRun(mergedConfig Config, runID string, envSe
 			containerInfo := v
 			status := containerInfo["status"]
 			if status == "running" {
-				dc.Logger.Log("debug", fmt.Sprintf("Here are logs of container: %s, which status is: %s\n%s",
+				dc.Logger.Log("info", fmt.Sprintf("Here are logs of container: %s, which status is: %s\n%s",
 					k, status, containerInfo["logs"]))
 			} else if status == "exited" {
-				dc.Logger.Log("debug", fmt.Sprintf("Here are logs of container: %s, which exited with exitcode: %s\n%s",
+				dc.Logger.Log("info", fmt.Sprintf("Here are logs of container: %s, which exited with exitcode: %s\n%s",
 					k, containerInfo["exitcode"], containerInfo["logs"]))
 			} else {
-				dc.Logger.Log("debug", fmt.Sprintf("Here are logs of container: %s, which status is: %s, exitcode: %s\n%s",
+				dc.Logger.Log("info", fmt.Sprintf("Here are logs of container: %s, which status is: %s, exitcode: %s\n%s",
 					k, status, containerInfo["exitcode"], containerInfo["logs"]))
 			}
 		}

--- a/docker_compose_driver_test.go
+++ b/docker_compose_driver_test.go
@@ -363,6 +363,8 @@ func TestDockerComposeDriver_HandleRun_Unit_PrintLogsAlways(t *testing.T) {
 		[]string{fakePSOutput, "", "0" }
 	commandsReactions["docker-compose -f docker-compose.yml -f docker-compose.yml.dojo -p 1234 config --services"] =
 		[]string{"container1", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] = []string{"some_hash running 0", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] = []string{"some_hash running 127", "", "0"}
 
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
@@ -467,8 +469,8 @@ func Test_getDefaultContainerID(t *testing.T) {
 	fs := NewMockedFileService(logger)
 
 	commandsReactions := make(map[string]interface{}, 0)
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}}' edudocker_default_run_1"] =
-		[]string{"dummy-id running", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_default_run_1"] =
+		[]string{"dummy-id running 000", "", "0" }
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
 
@@ -500,7 +502,7 @@ func Test_checkContainerIsRunning(t *testing.T) {
 	fs := NewMockedFileService(logger)
 
 	commandsReactions := make(map[string]interface{}, 0)
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}}' id1"] =	[]string{"id1 running", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' id1"] =	[]string{"id1 running 0", "", "0" }
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
 
@@ -515,12 +517,12 @@ func Test_waitForContainersToBeRunning(t *testing.T) {
 	commandsReactions := make(map[string]interface{}, 0)
 	commandsReactions["docker-compose -f docker-compose.yml -f docker-compose.yml.dojo -p 1234 ps"] =
 		[]string{fakePSOutput, "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}}' edudocker_abc_1"] =
-		[]string{"id1 running", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}}' edudocker_def_1"] =
-		[]string{"id2 running", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}}' edudocker_default_run_1"] =
-		[]string{"id3 running", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] =
+		[]string{"id1 running 0", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] =
+		[]string{"id2 running 0", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_default_run_1"] =
+		[]string{"id3 running 0", "", "0" }
 	fakeContainers := `abc
 cde
 efd

--- a/docker_compose_driver_test.go
+++ b/docker_compose_driver_test.go
@@ -299,10 +299,10 @@ func TestDockerComposeDriver_HandleRun_Unit(t *testing.T) {
 		[]string{fakePSOutput, "", "0" }
 	commandsReactions["docker-compose -f docker-compose.yml -f docker-compose.yml.dojo -p 1234 config --services"] =
 		[]string{"container1", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] =
-		[]string{"container1 running 0", "", "0"}
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] =
-		[]string{"container1 running 0", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] =
+		[]string{"container1 name1 running 0", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] =
+		[]string{"container1 name2 running 0", "", "0"}
 
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
@@ -340,10 +340,10 @@ func TestDockerComposeDriver_HandleRun_Unit_PrintLogsFailure(t *testing.T) {
 		[]string{fakePSOutput, "", "0" }
 	commandsReactions["docker-compose -f docker-compose.yml -f docker-compose.yml.dojo -p 1234 config --services"] =
 		[]string{"container1", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] =
-		[]string{"container1 running 0", "", "0"}
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] =
-		[]string{"container1 running 0", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] =
+		[]string{"container1 name1 running 0", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] =
+		[]string{"container1 name1 running 0", "", "0"}
 
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
@@ -371,8 +371,8 @@ func TestDockerComposeDriver_HandleRun_Unit_PrintLogsAlways(t *testing.T) {
 		[]string{fakePSOutput, "", "0" }
 	commandsReactions["docker-compose -f docker-compose.yml -f docker-compose.yml.dojo -p 1234 config --services"] =
 		[]string{"container1", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] = []string{"some_hash running 0", "", "0"}
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] = []string{"some_hash running 127", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] = []string{"some_hash name1 running 0", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] = []string{"some_hash name2 running 127", "", "0"}
 
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
@@ -401,8 +401,8 @@ func TestDockerComposeDriver_HandleRun_RealFileService(t *testing.T) {
 		[]string{fakePSOutput, "", "0" }
 	commandsReactions["docker-compose -f test-docker-compose.yml -f test-docker-compose.yml.dojo -p 1234 config --services"] =
 		[]string{"container1", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] = []string{"some_hash running 0", "", "0"}
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] = []string{"some_hash running 127", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] = []string{"some_hash name1 running 0", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] = []string{"some_hash name2 running 127", "", "0"}
 
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
@@ -441,8 +441,8 @@ func TestDockerComposeDriver_HandleRun_RealEnvService(t *testing.T) {
 		[]string{fakePSOutput, "", "0" }
 	commandsReactions["docker-compose -f docker-compose.yml -f docker-compose.yml.dojo -p 1234 config --services"] =
 		[]string{"container1", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] = []string{"some_hash running 0", "", "0"}
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] = []string{"some_hash running 127", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] = []string{"some_hash name1 running 0", "", "0"}
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] = []string{"some_hash name2 running 127", "", "0"}
 
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
@@ -481,8 +481,8 @@ func Test_getDefaultContainerID(t *testing.T) {
 	fs := NewMockedFileService(logger)
 
 	commandsReactions := make(map[string]interface{}, 0)
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_default_run_1"] =
-		[]string{"dummy-id running 000", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_default_run_1"] =
+		[]string{"dummy-id name1 running 000", "", "0" }
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
 
@@ -514,7 +514,7 @@ func Test_checkContainerIsRunning(t *testing.T) {
 	fs := NewMockedFileService(logger)
 
 	commandsReactions := make(map[string]interface{}, 0)
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' id1"] =	[]string{"id1 running 0", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' id1"] =	[]string{"id1 name1 running 0", "", "0" }
 	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	driver := NewDockerComposeDriver(shellS, fs, logger)
 
@@ -529,12 +529,12 @@ func Test_waitForContainersToBeRunning(t *testing.T) {
 	commandsReactions := make(map[string]interface{}, 0)
 	commandsReactions["docker-compose -f docker-compose.yml -f docker-compose.yml.dojo -p 1234 ps"] =
 		[]string{fakePSOutput, "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] =
-		[]string{"id1 running 0", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] =
-		[]string{"id2 running 0", "", "0" }
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' edudocker_default_run_1"] =
-		[]string{"id3 running 0", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_abc_1"] =
+		[]string{"id1 name1 running 0", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_def_1"] =
+		[]string{"id2 name2 running 0", "", "0" }
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' edudocker_default_run_1"] =
+		[]string{"id3 name3 running 0", "", "0" }
 	fakeContainers := `abc
 cde
 efd
@@ -595,35 +595,59 @@ default`
 }
 
 func Test_checkIfAnyContainerFailed_allSucceeded(t *testing.T) {
-	nonDefContInfos := make(map[string](map[string]string), 0)
-	cont1Info := make(map[string]string)
-	cont1Info["exitcode"] = "0"
-	nonDefContInfos["cont1"] = cont1Info
-	cont2Info := make(map[string]string)
-	cont2Info["exitcode"] = "0"
-	nonDefContInfos["cont2"] = cont2Info
+	nonDefContInfos := make([]*ContainerInfo, 0)
+	cont1Info := &ContainerInfo{
+		ExitCode: "0",
+	}
+	nonDefContInfos = append(nonDefContInfos, cont1Info)
+	cont2Info := &ContainerInfo{
+		ExitCode: "0",
+	}
+	nonDefContInfos = append(nonDefContInfos, cont2Info)
 	anyContFailed := checkIfAnyContainerFailed(nonDefContInfos, 0)
 	assert.False(t, anyContFailed)
 }
 func Test_checkIfAnyContainerFailed_defaultFailed(t *testing.T) {
-	nonDefContInfos := make(map[string](map[string]string), 0)
-	cont1Info := make(map[string]string)
-	cont1Info["exitcode"] = "0"
-	nonDefContInfos["cont1"] = cont1Info
-	cont2Info := make(map[string]string)
-	cont2Info["exitcode"] = "0"
-	nonDefContInfos["cont2"] = cont2Info
+	nonDefContInfos := make([]*ContainerInfo, 0)
+	cont1Info := &ContainerInfo{
+		ExitCode: "0",
+	}
+	nonDefContInfos = append(nonDefContInfos, cont1Info)
+	cont2Info := &ContainerInfo{
+		ExitCode: "0",
+	}
+	nonDefContInfos = append(nonDefContInfos, cont2Info)
 	anyContFailed := checkIfAnyContainerFailed(nonDefContInfos, 3)
 	assert.True(t, anyContFailed)
 }
 func Test_checkIfAnyContainerFailed_nonDefFailed(t *testing.T) {
-	nonDefContInfos := make(map[string](map[string]string), 0)
-	cont1Info := make(map[string]string)
-	cont1Info["exitcode"] = "0"
-	nonDefContInfos["cont1"] = cont1Info
-	cont2Info := make(map[string]string)
-	cont2Info["exitcode"] = "144"
-	nonDefContInfos["cont2"] = cont2Info
+	nonDefContInfos := make([]*ContainerInfo, 0)
+	cont1Info := &ContainerInfo{
+		ExitCode: "0",
+	}
+	nonDefContInfos = append(nonDefContInfos, cont1Info)
+	cont2Info := &ContainerInfo{
+		ExitCode: "144",
+	}
+	nonDefContInfos = append(nonDefContInfos, cont2Info)
 	anyContFailed := checkIfAnyContainerFailed(nonDefContInfos, 0)
 	assert.True(t, anyContFailed)
+}
+
+func Test_getNonDefaultContainersLogs(t *testing.T) {
+	nonDefContInfos := make([]*ContainerInfo, 0)
+	cont1Info := &ContainerInfo{
+		Name: "name1",
+	}
+	nonDefContInfos = append(nonDefContInfos, cont1Info)
+	commandsReactions := make(map[string]interface{}, 0)
+	commandsReactions["docker logs name1"] =
+		[]string{"123", "", "0"}
+
+	logger := NewLogger("debug")
+	fs := NewMockedFileService(logger)
+	shellS := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
+	driver := NewDockerComposeDriver(shellS, fs, logger)
+	driver.getNonDefaultContainersLogs(nonDefContInfos)
+	assert.Equal(t, nonDefContInfos[0].Logs, "stderr:\nstdout:\n123")
 }

--- a/shell_test.go
+++ b/shell_test.go
@@ -15,10 +15,13 @@ type MockedShellServiceNotInteractive struct {
 	CommandsReactions map[string]interface{}
 	CommandsRun []string
 	Environment []string
+	Mutex *sync.Mutex
 }
 func NewMockedShellServiceNotInteractive(logger *Logger) *MockedShellServiceNotInteractive {
 	return &MockedShellServiceNotInteractive{
 		Logger: logger,
+		Mutex: &sync.Mutex{},
+		CommandsRun: make([]string, 0),
 	}
 }
 func (bs MockedShellServiceNotInteractive) SetEnvironment(variables []string) {
@@ -31,13 +34,14 @@ func NewMockedShellServiceNotInteractive2(logger *Logger, commandsReactions map[
 	return &MockedShellServiceNotInteractive{
 		Logger: logger,
 		CommandsReactions: commandsReactions,
+		Mutex: &sync.Mutex{},
+		CommandsRun: make([]string, 0),
 	}
 }
 func (ss *MockedShellServiceNotInteractive) AppendCommandRun(command string) {
-	if ss.CommandsRun == nil {
-		ss.CommandsRun = make([]string, 0)
-	}
+	ss.Mutex.Lock()
 	ss.CommandsRun = append(ss.CommandsRun, command)
+	ss.Mutex.Unlock()
 }
 func (bs MockedShellServiceNotInteractive) RunInteractive(cmdString string, separePGroup bool) (int, bool) {
 	cmd := fmt.Sprintf("Pretending to run: %s", cmdString)
@@ -85,13 +89,11 @@ func (bs MockedShellServiceInteractive) SetEnvironment(variables []string) {
 func NewMockedShellServiceInteractive(logger *Logger) *MockedShellServiceInteractive {
 	return &MockedShellServiceInteractive{
 		Logger: logger,
+		Mutex: &sync.Mutex{},
+		CommandsRun: make([]string, 0),
 	}
 }
 func (ss *MockedShellServiceInteractive) AppendCommandRun(command string) {
-	if ss.CommandsRun == nil {
-		ss.Mutex = &sync.Mutex{}
-		ss.CommandsRun = make([]string, 0)
-	}
 	ss.Mutex.Lock()
 	ss.CommandsRun = append(ss.CommandsRun, command)
 	ss.Mutex.Unlock()

--- a/tasks
+++ b/tasks
@@ -42,7 +42,7 @@ case "${command}" in
         chmod +x ./bin/dojo
         ;;
     unit)
-        (set -x; go test -v -race ./...; )
+        (set -x; go test -v -race ./... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''; )
         ;;
     e2e_py)
         python3 -m venv venv

--- a/test/support/common.py
+++ b/test/support/common.py
@@ -4,8 +4,10 @@ import subprocess
 test_dir = str(os.path.dirname(os.path.abspath(__file__)))
 project_root = os.path.join(test_dir, '..', '..')
 
+
 def decode_utf8(bytes):
     return bytes.decode('utf-8')
+
 
 def run_command(exe, args, env=None):
     cwd = project_root
@@ -17,12 +19,15 @@ def run_command(exe, args, env=None):
     result.stderr = decode_utf8(result.stderr)
     return result
 
+
 def run_shell(command):
     return subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+
 
 def run_dojo(args, env=None):
     dojo_exe = os.path.join(test_dir, '..', '..', 'bin', 'dojo')
     return run_command(dojo_exe, args, env)
+
 
 def assert_no_warnings_or_errors(text):
     assert not 'warn' in text

--- a/test/test-files/itest-dc-verbose-fail.yaml
+++ b/test/test-files/itest-dc-verbose-fail.yaml
@@ -1,0 +1,19 @@
+version: '2.2'
+services:
+  default:
+    # this option is needed to make default docker container preserve signals,
+    # sh shell does not preserve them
+    init: true
+    # this option is ignored by "docker-compose run", which is used by Dojo
+    # container_name: whatever
+    links:
+    - abc:abc
+    volumes:
+    - /tmp/dojo-itest-dc:/tmp/dojo-itest-dc
+    environment:
+      ABC_DEF: "1234"
+  abc:
+    init: true
+    image: alpine:3.8
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["some-non-existent-command"]

--- a/test/test-files/itest-dc-verbose.yaml
+++ b/test/test-files/itest-dc-verbose.yaml
@@ -1,0 +1,20 @@
+version: '2.2'
+services:
+  default:
+    # this option is needed to make default docker container preserve signals,
+    # sh shell does not preserve them
+    init: true
+    # this option is ignored by "docker-compose run", which is used by Dojo
+    # container_name: whatever
+    links:
+    - abc:abc
+    volumes:
+    - /tmp/dojo-itest-dc:/tmp/dojo-itest-dc
+    environment:
+      ABC_DEF: "1234"
+  abc:
+    init: true
+    image: alpine:3.8
+    entrypoint: ["/bin/sh", "-c"]
+    # (double dolar sign is to escape the single dolar sign: https://stackoverflow.com/a/40621373/4457564)
+    command: ["i=0; while true; do i=$$((i+1)); echo iteration: $$i; sleep 1; done;"]

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -1,11 +1,12 @@
 import pytest
-
 from .support.common import run_dojo
+
 
 def test_version_output():
     result = run_dojo(['--version'])
     assert 'Dojo version' in result.stderr #TODO: (ewa) should be in stdout
     assert result.returncode == 0
+
 
 def test_help_output():
     result = run_dojo(['--help'])

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -1,17 +1,19 @@
 from test.support.common import *
 
 
-def cleanUpDockerContainer():
-  run_shell('docker ps -a -q --filter "name=testdojorunid" | xargs --no-run-if-empty docker stop')
-  run_shell('docker ps -a -q --filter "name=testdojorunid" | xargs --no-run-if-empty docker rm')
+def clean_up_docker_container():
+    run_shell('docker ps -a -q --filter "name=testdojorunid" | xargs --no-run-if-empty docker stop')
+    run_shell('docker ps -a -q --filter "name=testdojorunid" | xargs --no-run-if-empty docker rm')
 
-def testDockerContainerIsRemoved():
-  result = run_command('docker', ['ps', '-a', '--filter', "name=testdojorunid"])
-  assert not 'testdojorunid' in result.stderr
-  assert result.returncode == 0
+
+def test_docker_container_is_removed():
+    result = run_command('docker', ['ps', '-a', '--filter', "name=testdojorunid"])
+    assert not 'testdojorunid' in result.stderr
+    assert result.returncode == 0
+
 
 def test_docker_when_zero_exit():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     result = run_dojo('--debug=true --test=true --image=alpine:3.8 whoami'.split(' '))
     assert 'Dojo version' in result.stderr
     assert 'root' in result.stdout
@@ -22,10 +24,11 @@ def test_docker_when_zero_exit():
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 0
-    testDockerContainerIsRemoved()
+    test_docker_container_is_removed()
+
 
 def test_docker_capture_output():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     result = run_dojo(['--debug=true', '--test=true', '--image=alpine:3.8', 'sh', '-c', "printenv HOME"])
     assert 'Dojo version' in result.stderr
     assert '/root\n' == result.stdout
@@ -35,20 +38,22 @@ def test_docker_capture_output():
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 0
-    testDockerContainerIsRemoved()
+    test_docker_container_is_removed()
+
 
 def test_docker_when_non_existent_command():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     result = run_dojo('--debug=true --test=true --image=alpine:3.8 notexistentcommand'.split(' '))
     assert 'Dojo version' in result.stderr
     assert 'executable file not found' in result.stderr
     assert 'Exit status from run command: 127' in result.stderr
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 127
-    testDockerContainerIsRemoved()
+    test_docker_container_is_removed()
+
 
 def test_docker_when_no_command():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     result = run_dojo('--debug=true --test=true --image=alpine:3.8 -i=false'.split(' '))
     assert 'Dojo version' in result.stderr
     assert 'Exit status from run command: 0' in result.stderr
@@ -57,10 +62,11 @@ def test_docker_when_no_command():
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 0
-    testDockerContainerIsRemoved()
+    test_docker_container_is_removed()
+
 
 def test_docker_when_double_dash_command_split():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     result = run_dojo('--debug=true --test=true --image=alpine:3.8 -- whoami'.split(' '))
     assert 'Dojo version' in result.stderr
     assert 'root' in result.stdout
@@ -71,10 +77,11 @@ def test_docker_when_double_dash_command_split():
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 0
-    testDockerContainerIsRemoved()
+    test_docker_container_is_removed()
+
 
 def test_docker_when_shell_command():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     result = run_dojo(['--debug=true', '--test=true', '--image=alpine:3.8', 'sh', '-c', 'echo hello'])
     assert 'Dojo version' in result.stderr
     assert 'hello' in result.stdout
@@ -84,10 +91,11 @@ def test_docker_when_shell_command():
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 0
-    testDockerContainerIsRemoved()
+    test_docker_container_is_removed()
+
 
 def test_docker_preserves_env_vars():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     envs = dict(os.environ)
     envs['ABC'] = 'custom_value'
     result = run_dojo(
@@ -100,8 +108,9 @@ def test_docker_preserves_env_vars():
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 0
 
+
 def test_docker_preserves_multiline_env_vars():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     envs = dict(os.environ)
     envs['ABC'] = """first line
 second line"""
@@ -117,8 +126,9 @@ second line"""
     assert """first line
 second line""" in result.stdout
 
+
 def test_docker_when_custom_relative_directory():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     result = run_dojo(['-c', 'test/test-files/Dojofile', '--debug=true', '--test=true', '--image=alpine:3.8', 'whoami'])
     assert 'Dojo version' in result.stderr
     assert 'root' in result.stdout
@@ -128,10 +138,11 @@ def test_docker_when_custom_relative_directory():
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 0
-    testDockerContainerIsRemoved()
+    test_docker_container_is_removed()
+
 
 def test_docker_when_nonexistent_custom_relative_directory():
-    cleanUpDockerContainer()
+    clean_up_docker_container()
     try:
         os.removedirs(os.path.join(project_root, 'test/test-files/not-existent'))
     except FileNotFoundError:
@@ -145,7 +156,8 @@ def test_docker_when_nonexistent_custom_relative_directory():
     assert 'Exit status from cleaning: 0' in result.stderr
     assert 'Exit status from signals: 0' in result.stderr
     assert result.returncode == 0
-    testDockerContainerIsRemoved()
+    test_docker_container_is_removed()
+
 
 def test_docker_pull():
     result = run_dojo('--debug=true --action=pull --image=alpine:3.8'.split(' '))

--- a/test/test_docker_compose.py
+++ b/test/test_docker_compose.py
@@ -192,6 +192,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_all_constainer
     # make the command of the default container last long enough so that the other
     # container is started and managed to produce some output
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-verbose.yaml',
+                       '--print-logs=always',
                        '--debug=true', '--test=true', '--image=alpine:3.8', '--', 'sh',
                        '-c', "echo 1; sleep 1; echo 2; sleep 1;"])
     assert 'Dojo version' in result.stderr
@@ -214,6 +215,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_nondefault_con
     # make the command of the default container last long enough so that the other
     # container is started and managed to produce some output
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-verbose-fail.yaml',
+                       '--print-logs=always',
                        '--debug=true', '--test=true', '--image=alpine:3.8', '--', 'sh',
                        '-c', "echo 1; sleep 1; echo 2; sleep 1;"])
     assert 'Dojo version' in result.stderr
@@ -235,7 +237,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_default_contai
     clean_up_dc_dojofile()
     # make the command of the default container last long enough so that the other
     # container is started and managed to produce some output
-    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.8 -- some-non-existent-command".split())
+    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc-verbose.yaml --print-logs=failure --debug=true --test=true --image=alpine:3.8 -- some-non-existent-command".split())
     assert 'Dojo version' in result.stderr
     assert result.returncode == 127
     assert 'Exit status from run command: 127' in result.stderr

--- a/test/test_docker_compose.py
+++ b/test/test_docker_compose.py
@@ -183,3 +183,66 @@ def test_docker_compose_dojo_work_variables():
     test_dc_dojofile_is_removed()
     test_dc_containers_are_removed()
     test_dc_network_is_removed()
+
+
+def test_docker_compose_run_shows_nondefault_containers_logs_when_all_constainers_succeeded():
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
+    # make the command of the default container last long enough so that the other
+    # container is started and managed to produce some output
+    result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-verbose.yaml',
+                       '--debug=true', '--test=true', '--image=alpine:3.8', '--', 'sh',
+                       '-c', "echo 1; sleep 1; echo 2; sleep 1;"])
+    assert 'Dojo version' in result.stderr
+    assert result.returncode == 0
+    assert 'echo 1; sleep 1; echo 2; sleep 1;' in result.stderr
+    assert 'Exit status from run command: 0' in result.stderr
+    assert 'Here are logs of container: testdojorunid_abc_1' in result.stderr
+    assert 'iteration: 1' in result.stderr
+    assert_no_warnings_or_errors(result.stderr)
+    assert_no_warnings_or_errors(result.stdout)
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()
+
+
+def test_docker_compose_run_shows_nondefault_containers_logs_when_nondefault_container_failed():
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
+    # make the command of the default container last long enough so that the other
+    # container is started and managed to produce some output
+    result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-verbose-fail.yaml',
+                       '--debug=true', '--test=true', '--image=alpine:3.8', '--', 'sh',
+                       '-c', "echo 1; sleep 1; echo 2; sleep 1;"])
+    assert 'Dojo version' in result.stderr
+    assert result.returncode == 0
+    assert 'echo 1; sleep 1; echo 2; sleep 1;' in result.stderr
+    assert 'Exit status from run command: 0' in result.stderr
+    assert 'Here are logs of container: testdojorunid_abc_1' in result.stderr
+    assert 'some-non-existent-command: not found' in result.stderr
+    assert_no_warnings_or_errors(result.stderr)
+    assert_no_warnings_or_errors(result.stdout)
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()
+
+
+def test_docker_compose_run_shows_nondefault_containers_logs_when_default_container_failed():
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
+    # make the command of the default container last long enough so that the other
+    # container is started and managed to produce some output
+    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.8 -- some-non-existent-command".split())
+    assert 'Dojo version' in result.stderr
+    assert result.returncode == 127
+    assert 'Exit status from run command: 127' in result.stderr
+    assert 'Here are logs of container: testdojorunid_abc_1' in result.stderr
+    assert 'iteration: 1' in result.stderr
+    assert_no_warnings_or_errors(result.stderr)
+    assert_no_warnings_or_errors(result.stdout)
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()

--- a/test/test_docker_compose.py
+++ b/test/test_docker_compose.py
@@ -200,6 +200,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_all_constainer
     assert 'echo 1; sleep 1; echo 2; sleep 1;' in result.stderr
     assert 'Exit status from run command: 0' in result.stderr
     assert 'Here are logs of container: testdojorunid_abc_1' in result.stderr
+    assert 'which status is: running' in result.stderr
     assert 'iteration: 1' in result.stderr
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
@@ -223,6 +224,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_nondefault_con
     assert 'echo 1; sleep 1; echo 2; sleep 1;' in result.stderr
     assert 'Exit status from run command: 0' in result.stderr
     assert 'Here are logs of container: testdojorunid_abc_1' in result.stderr
+    assert 'which exited with exitcode: 127' in result.stderr
     assert 'some-non-existent-command: not found' in result.stderr
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
@@ -242,6 +244,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_default_contai
     assert result.returncode == 127
     assert 'Exit status from run command: 127' in result.stderr
     assert 'Here are logs of container: testdojorunid_abc_1' in result.stderr
+    assert 'which status is: running' in result.stderr
     assert 'iteration: 1' in result.stderr
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)

--- a/test/test_docker_compose.py
+++ b/test/test_docker_compose.py
@@ -1,41 +1,45 @@
 import os
-
 from .support.common import *
 
 
-def cleanUpDCDojoFile():
+def clean_up_dc_dojofile():
     try:
         os.remove(os.path.join(project_root, 'test/test-files/itest-dc.yaml.dojo'))
     except FileNotFoundError:
         pass
 
-def testDCDojoFileIsRemoved():
+
+def test_dc_dojofile_is_removed():
     assert not os.path.exists(os.path.join(project_root, 'test/test-files/itest-dc.yaml.dojo'))
 
-def cleanUpDCContainers():
+
+def clean_up_dc_containers():
     run_command('docker', ['stop', 'testdojorunid_default_run_1'])
     run_command('docker', ['stop', 'testdojorunid_abc_1'])
     run_command('docker', ['rm', 'testdojorunid_default_run_1'])
     run_command('docker', ['rm', 'testdojorunid_abc_1'])
 
-def testDCContainersAreRemoved():
+
+def test_dc_containers_are_removed():
     result = run_command('docker', ['ps', '-a', '--filter', 'name=testdojorunid'])
     assert not "testdojorunid" in result.stdout
     assert result.returncode == 0
 
-def cleanUpDCNetwork():
+
+def clean_up_dc_network():
     run_command('docker', ['network', 'rm', 'testdojorunid_default'])
 
-def testDCNetworkIsRemoved():
+
+def test_dc_network_is_removed():
     result = run_command('docker',  ['network', 'ls', '--filter', "name=testdojorunid"])
     assert not "testdojorunid" in result.stdout
     assert result.returncode == 0
 
 
 def test_docker_compose_run_when_exit_zero():
-    cleanUpDCContainers()
-    cleanUpDCNetwork()
-    cleanUpDCDojoFile()
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
     result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.8 whoami".split(' '))
     assert 'Dojo version' in result.stderr
     assert result.returncode == 0
@@ -44,14 +48,15 @@ def test_docker_compose_run_when_exit_zero():
     assert 'Exit status from run command: 0' in result.stderr
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
-    testDCDojoFileIsRemoved()
-    testDCContainersAreRemoved()
-    testDCNetworkIsRemoved()
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()
+
 
 def test_docker_compose_run_command_output_capture():
-    cleanUpDCContainers()
-    cleanUpDCNetwork()
-    cleanUpDCDojoFile()
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.8', 'sh', '-c', "printenv HOME"])
     assert result.stdout == '/root\n'
     assert "Exit status from run command: 0" in result.stderr
@@ -59,24 +64,26 @@ def test_docker_compose_run_command_output_capture():
     assert "Exit status from signals: 0" in result.stderr
     assert "Dojo version" in result.stderr
 
+
 def test_docker_compose_run_when_exit_non_zero():
-    cleanUpDCContainers()
-    cleanUpDCNetwork()
-    cleanUpDCDojoFile()
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
     result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.8 notexistentcommand".split(' '))
     assert 'Dojo version' in result.stderr
     assert "Current shell is interactive: false" in result.stderr
     assert "exec notexistentcommand failed: No such file or directory" in result.stderr
     assert "Exit status from run command: 127" in result.stderr
     assert 127 == result.returncode
-    testDCDojoFileIsRemoved()
-    testDCContainersAreRemoved()
-    testDCNetworkIsRemoved()
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()
+
 
 def test_docker_compose_run_when_double_dash_command_split():
-    cleanUpDCContainers()
-    cleanUpDCNetwork()
-    cleanUpDCDojoFile()
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
     result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.8 -- whoami".split())
     assert 'Dojo version' in result.stderr
     assert result.returncode == 0
@@ -85,14 +92,15 @@ def test_docker_compose_run_when_double_dash_command_split():
     assert 'Exit status from run command: 0' in result.stderr
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
-    testDCDojoFileIsRemoved()
-    testDCContainersAreRemoved()
-    testDCNetworkIsRemoved()
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()
+
 
 def test_docker_compose_run_when_shell_command():
-    cleanUpDCContainers()
-    cleanUpDCNetwork()
-    cleanUpDCDojoFile()
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
     result = run_dojo(['--driver=docker-compose',  '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.8', 'sh', '-c', 'echo hello'])
     assert 'Dojo version' in result.stderr
     assert 'Exit status from run command: 0' in result.stderr
@@ -100,14 +108,15 @@ def test_docker_compose_run_when_shell_command():
     assert result.returncode == 0
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
-    testDCDojoFileIsRemoved()
-    testDCContainersAreRemoved()
-    testDCNetworkIsRemoved()
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()
+
 
 def test_docker_compose_run_preserves_env_vars():
-    cleanUpDCContainers()
-    cleanUpDCNetwork()
-    cleanUpDCDojoFile()
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
     envs = dict(os.environ)
     envs['ABC'] ='custom_value'
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.8', 'sh', '-c', 'env | grep ABC'],
@@ -117,14 +126,15 @@ def test_docker_compose_run_preserves_env_vars():
     assert '1234' in result.stdout
     assert 'Exit status from run command: 0' in result.stderr
     assert result.returncode == 0
-    testDCDojoFileIsRemoved()
-    testDCContainersAreRemoved()
-    testDCNetworkIsRemoved()
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()
+
 
 def test_docker_compose_run_preserves_multiline_env_vars():
-    cleanUpDCContainers()
-    cleanUpDCNetwork()
-    cleanUpDCDojoFile()
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
     envs = dict(os.environ)
     envs['ABC'] = """first line
 second line"""
@@ -139,9 +149,10 @@ second line"""
     assert 'Exit status from run command:' in result.stderr
     assert """first line
 second line""" in result.stdout
-    testDCDojoFileIsRemoved()
-    testDCContainersAreRemoved()
-    testDCNetworkIsRemoved()
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()
+
 
 def test_docker_compose_pull():
     result = run_dojo('--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --action=pull --image=alpine:3.8'.split(' '))
@@ -151,10 +162,11 @@ def test_docker_compose_pull():
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
 
+
 def test_docker_compose_dojo_work_variables():
-    cleanUpDCContainers()
-    cleanUpDCNetwork()
-    cleanUpDCDojoFile()
+    clean_up_dc_containers()
+    clean_up_dc_network()
+    clean_up_dc_dojofile()
     os.makedirs(os.path.join(project_root, 'test/test-files/custom-dir-env-var'), exist_ok=True)
     with open(os.path.join(project_root, 'test/test-files/custom-dir-env-var/file1.txt'), 'w') as f:
         f.write('123')
@@ -168,6 +180,6 @@ def test_docker_compose_dojo_work_variables():
     assert_no_warnings_or_errors(result.stderr)
     assert_no_warnings_or_errors(result.stdout)
     assert result.returncode == 0
-    testDCDojoFileIsRemoved()
-    testDCContainersAreRemoved()
-    testDCNetworkIsRemoved()
+    test_dc_dojofile_is_removed()
+    test_dc_containers_are_removed()
+    test_dc_network_is_removed()

--- a/utils.go
+++ b/utils.go
@@ -130,32 +130,35 @@ func removeWhiteSpaces(str string) string {
 
 type ContainerInfo struct {
 	ID     string
+	Name     string
 	Status string
 	ExitCode string
 	Exists bool
+	Logs string
 }
 
 // Returns: container ID, status , whether or not a container exists, error
-func getContainerInfo(shellService ShellServiceInterface, containerNameOrID string) (ContainerInfo, error) {
+func getContainerInfo(shellService ShellServiceInterface, containerNameOrID string) (*ContainerInfo, error) {
 	if containerNameOrID == "" {
 		panic("containerNameOrID was empty")
 	}
 	// https://docs.docker.com/engine/api/v1.21/
-	cmd := fmt.Sprintf("docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' %s", containerNameOrID)
+	cmd := fmt.Sprintf("docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' %s", containerNameOrID)
 	stdout, stderr, exitStatus, _ := shellService.RunGetOutput(cmd, true)
 	if exitStatus != 0 {
 		if strings.Contains(stdout, "No such object") || strings.Contains(stderr, "No such object") {
-			return ContainerInfo{Exists: false}, nil
+			return &ContainerInfo{Exists: false}, nil
 		}
 		cmdInfo := cmdInfoToString(cmd, stdout, stderr, exitStatus)
-		return ContainerInfo{}, fmt.Errorf("Unexpected exit status:\n%s", cmdInfo)
+		return &ContainerInfo{}, fmt.Errorf("Unexpected exit status:\n%s", cmdInfo)
 	}
 	status := strings.TrimSuffix(stdout, "\n")
 	outputArr := strings.Split(status, " ")
-	return ContainerInfo{
+	return &ContainerInfo{
 		ID:     outputArr[0],
-		Status: outputArr[1],
-		ExitCode: outputArr[2],
+		Name:     strings.TrimSuffix(outputArr[1], "/"),
+		Status: outputArr[2],
+		ExitCode: outputArr[3],
 		Exists: true,
 	}, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -131,6 +131,7 @@ func removeWhiteSpaces(str string) string {
 type ContainerInfo struct {
 	ID     string
 	Status string
+	ExitCode string
 	Exists bool
 }
 
@@ -139,7 +140,8 @@ func getContainerInfo(shellService ShellServiceInterface, containerNameOrID stri
 	if containerNameOrID == "" {
 		panic("containerNameOrID was empty")
 	}
-	cmd := fmt.Sprintf("docker inspect --format='{{.Id}} {{.State.Status}}' %s", containerNameOrID)
+	// https://docs.docker.com/engine/api/v1.21/
+	cmd := fmt.Sprintf("docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' %s", containerNameOrID)
 	stdout, stderr, exitStatus, _ := shellService.RunGetOutput(cmd, true)
 	if exitStatus != 0 {
 		if strings.Contains(stdout, "No such object") || strings.Contains(stderr, "No such object") {
@@ -153,6 +155,7 @@ func getContainerInfo(shellService ShellServiceInterface, containerNameOrID stri
 	return ContainerInfo{
 		ID:     outputArr[0],
 		Status: outputArr[1],
+		ExitCode: outputArr[2],
 		Exists: true,
 	}, nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -127,13 +127,14 @@ bb
 func Test_getContainerInfo(t *testing.T) {
 	logger := NewLogger("debug")
 	commandsReactions := make(map[string]interface{}, 0)
-	fakeOutput := `1234 running`
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}}' 1234"] =
+	fakeOutput := `1234 running 133`
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' 1234"] =
 		[]string{fakeOutput, "", "0" }
 	shell := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	info, err := getContainerInfo(shell, "1234")
 	assert.Equal(t, "1234", info.ID)
 	assert.Equal(t, "running", info.Status)
+	assert.Equal(t, "133", info.ExitCode)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, true, info.Exists)
 }
@@ -141,7 +142,7 @@ func Test_getContainerInfo(t *testing.T) {
 func Test_getContainerInfo_NoSuchObject(t *testing.T) {
 	logger := NewLogger("debug")
 	commandsReactions := make(map[string]interface{}, 0)
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}}' 1234"] =
+	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' 1234"] =
 		[]string{"", "Error: No such object: 1234", "1" }
 	shell := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	info, err := getContainerInfo(shell, "1234")

--- a/utils_test.go
+++ b/utils_test.go
@@ -127,12 +127,13 @@ bb
 func Test_getContainerInfo(t *testing.T) {
 	logger := NewLogger("debug")
 	commandsReactions := make(map[string]interface{}, 0)
-	fakeOutput := `1234 running 133`
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' 1234"] =
+	fakeOutput := `1234 name1 running 133`
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' 1234"] =
 		[]string{fakeOutput, "", "0" }
 	shell := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	info, err := getContainerInfo(shell, "1234")
 	assert.Equal(t, "1234", info.ID)
+	assert.Equal(t, "name1", info.Name)
 	assert.Equal(t, "running", info.Status)
 	assert.Equal(t, "133", info.ExitCode)
 	assert.Equal(t, nil, err)
@@ -142,7 +143,7 @@ func Test_getContainerInfo(t *testing.T) {
 func Test_getContainerInfo_NoSuchObject(t *testing.T) {
 	logger := NewLogger("debug")
 	commandsReactions := make(map[string]interface{}, 0)
-	commandsReactions["docker inspect --format='{{.Id}} {{.State.Status}} {{.State.ExitCode}}' 1234"] =
+	commandsReactions["docker inspect --format='{{.Id}} {{.Name}} {{.State.Status}} {{.State.ExitCode}}' 1234"] =
 		[]string{"", "Error: No such object: 1234", "1" }
 	shell := NewMockedShellServiceNotInteractive2(logger, commandsReactions)
 	info, err := getContainerInfo(shell, "1234")

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
-const DojoVersion = "0.6.3"
+const DojoVersion = "0.7.0"
 


### PR DESCRIPTION
This PR is to implement the feature described here: https://github.com/kudulab/dojo/issues/12

This feature is made up of 4 parts:
1. print logs from nondefault containers - done
2. be able to configure when to print them - done
3. be able to decide if print to stderr or to file
4. print info about a nondefault container status and exit code - done