### PR TITLE
verify if bash is installed #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.10.1 (2020-Oct-18)
+
+* Verify if Bash is installed when running Dojo. Dojo performs a shell out and Bash is its dependency. If Bash is not installed, a pretty error will be printed. [#22](https://github.com/kudulab/dojo/issues/22)
+
 ### 0.10.0 (2020-Sep-06)
 
 * Added support for [homebrew on Linux](https://github.com/kudulab/dojo/pull/20). Thanks to [Justin Garrison](https://github.com/rothgar)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A dojo docker image becomes a contract of what is a **correct environment** for 
 
 #### On Linux
 ```bash
-DOJO_VERSION=0.10.0
+DOJO_VERSION=0.10.1
 wget -O dojo https://github.com/kudulab/dojo/releases/download/${DOJO_VERSION}/dojo_linux_amd64
 sudo mv dojo /usr/local/bin
 sudo chmod +x /usr/local/bin/dojo
@@ -69,7 +69,7 @@ sudo chmod +x /usr/local/bin/dojo
 
 #### Using brew - on OSX or Linux
 ```bash
-DOJO_VERSION=0.10.0
+DOJO_VERSION=0.10.1
 wget -O dojo https://github.com/kudulab/dojo/releases/download/${DOJO_VERSION}/dojo_darwin_amd64
 mv dojo /usr/local/bin
 chmod +x /usr/local/bin/dojo
@@ -117,6 +117,7 @@ In practice this means Dojo works on **Linux or Mac**.
 Dojo is continuously tested only on Linux.
 
 ### Dependencies
+The following must be installed for Dojo to run:
 * Bash
 * [Docker](https://docs.docker.com/)
 * [Docker-Compose](https://github.com/docker/compose) >=1.7.1 (only if using Dojo driver: docker-compose)
@@ -129,7 +130,7 @@ brew install kudulab/homebrew-dojo-osx/dojo
 ```
 A manual install is another option:
 ```sh
-version="0.10.0"
+version="0.10.1"
 # on Linux:
 wget -O /tmp/dojo https://github.com/kudulab/dojo/releases/download/${version}/dojo_linux_amd64
 # or on Darwin:
@@ -171,7 +172,7 @@ We have also established several **best practices** for dojo image development:
 Dojo provides [several scripts](image_scripts/src) to be used inside dojo images to meet most of above requirements. Scripts can be installed in a `Dockerfile` with:
 
 ```dockerfile
-ENV DOJO_VERSION=0.10.0
+ENV DOJO_VERSION=0.10.1
 RUN git clone --depth 1 -b ${DOJO_VERSION} https://github.com/kudulab/dojo.git /tmp/dojo_git &&\
   /tmp/dojo_git/image_scripts/src/install.sh && \
   rm -r /tmp/dojo_git
@@ -201,7 +202,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 # Install common Dojo scripts
-ENV DOJO_VERSION=0.10.0
+ENV DOJO_VERSION=0.10.1
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo git ca-certificates && \
@@ -249,7 +250,7 @@ For alpine images a typical dockerfile has following structure:
 FROM alpine:3.9
 
 # Install common Dojo scripts
-ENV DOJO_VERSION=0.10.0
+ENV DOJO_VERSION=0.10.1
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
   apk add --no-cache tini bash shadow sudo git && \
   git clone --depth 1 -b ${DOJO_VERSION} https://github.com/kudulab/dojo.git /tmp/dojo_git &&\

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"sync"
 	"syscall"
@@ -66,9 +67,29 @@ func handleSignal(logger *Logger, mergedConfig Config, runID string, driver Dojo
 	return exitStatus
 }
 
+func verifyBashInstalled(logger Logger) {
+	bash_cmd := "bash"
+	bash_cmd_args := "--version"
+	cmd := exec.Command(bash_cmd, bash_cmd_args)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	if err != nil  {
+		logger.Log("error", fmt.Sprintf("Error while verifying if Bash is installed. Please make sure Bash is installed. Error: %s", err))
+		os.Exit(1)
+	}
+}
+
 func main() {
 	logger := NewLogger("debug")
 	logger.Log("info", fmt.Sprintf("Dojo version %s", DojoVersion))
+
+	// This will either result in exit or return nothing.
+	// In the future, if we support more shells, we can decide here which shell to use.
+	verifyBashInstalled(*logger)
+
 	mergedConfig := handleConfig(logger)
 
 	fileService := NewFileService(logger)

--- a/tasks
+++ b/tasks
@@ -45,14 +45,20 @@ case "${command}" in
         (set -x; go test -v -race ./... | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''; )
         ;;
     e2e_py)
+        echo "Running task: e2e_py"
         python3 -m venv venv
         source venv/bin/activate
         pip3 install -r test/requirements.txt
         pytest test --verbose
         ;;
+    e2e_invalid_environment)
+        echo "Running task: e2e_invalid_environment"
+        docker run -t --rm -v ${PWD}/bin/dojo:/usr/bin/dojo alpine:3.9 "/usr/bin/dojo" 2>&1 | grep "Error while verifying if Bash is installed" && true
+        ;;
     e2e)
         check_flavor $2
         dojo -c Dojofile.e2e-$2 "./tasks e2e_py"
+        ./tasks e2e_invalid_environment
         ;;
     test_signals)
         check_flavor $2

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
-const DojoVersion = "0.10.0"
+const DojoVersion = "0.10.1"
 


### PR DESCRIPTION
This PR adds a verification whether Bash is installed. It is invoked at the beginning of Dojo run. If Bash is not installed, a pretty error will be printed. Previously, running Dojo without Bash installed resulted in crash:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4ccbba]
```

This fixes issue #22. Added also a test to see if the pretty error is printed.