### PR TITLE
Fixes for the latest docker-compose versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           name: Install dojo
           command: |
-            version="0.10.5"
+            version="0.13.0"
             wget -O /tmp/dojo https://github.com/kudulab/dojo/releases/download/${version}/dojo_linux_amd64
             chmod +x /tmp/dojo
             sudo mv /tmp/dojo /usr/bin/dojo
@@ -69,7 +69,7 @@ jobs:
       - run:
           name: Install dojo
           command: |
-            version="0.10.5"
+            version="0.13.0"
             wget -O /tmp/dojo https://github.com/kudulab/dojo/releases/download/${version}/dojo_linux_amd64
             chmod +x /tmp/dojo
             sudo mv /tmp/dojo /usr/bin/dojo
@@ -87,7 +87,7 @@ jobs:
       - run:
           name: Install dojo
           command: |
-            version="0.10.5"
+            version="0.13.0"
             wget -O /tmp/dojo https://github.com/kudulab/dojo/releases/download/${version}/dojo_linux_amd64
             chmod +x /tmp/dojo
             sudo mv /tmp/dojo /usr/bin/dojo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.13.1 (2024-Dec-29)
+
+* docker-compose: support it when there is no version statement in the top of the yaml file; tested with docker-compose v2.24.5
+* docker-compose: fix json decoding on mac - the Publishers field was resulting in decoding errors
+* bump dojo image scripts base images
+  * alpine:3.21
+  * ubuntu:24.10
+
 ### 0.13.0 (2024-Feb-05)
 
 * Support multiple levels of log output produced by Dojo: `silent`, `error`, `warn`, `info`, `debug`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.13.1 (2024-Dec-29)
 
-* docker-compose: support it when there is no version statement in the top of the yaml file; tested with docker-compose v2.24.5
+* docker-compose: support it when there is no version statement in the top of the yaml file; tested with docker-compose v2.24.5 and v2.31.0
 * docker-compose: fix json decoding on mac - the Publishers field was resulting in decoding errors
 * bump dojo image scripts base images
   * alpine:3.21

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ brew install kudulab/homebrew-dojo-osx/dojo
 ```
 * a manual install:
 ```sh
-version="0.13.0"
+version="0.13.1"
 # on Linux:
 wget -O /tmp/dojo https://github.com/kudulab/dojo/releases/download/${version}/dojo_linux_amd64
 # or on Mac:
@@ -91,7 +91,7 @@ dojo "gradle test jar"
 The beginning of the output shows the docker command executed by Dojo:
 ```console
 /tmp/gocd-yaml-config-plugin$ dojo "gradle test jar"
-2020/12/09 07:40:28 [ 1]  INFO: (main.main) Dojo version 0.10.5
+2020/12/09 07:40:28 [ 1]  INFO: (main.main) Dojo version 0.13.1
 2020/12/09 07:40:28 [ 4]  INFO: (main.DockerDriver.HandleRun) docker command will be:
  docker run --rm -v /tmp/gocd-yaml-config-plugin:/dojo/work -v /home/tomzo:/dojo/identity:ro --env-file=/tmp/dojo-environment-dojo-gocd-yaml-config-plugin-2020-12-09_07-40-50-60121947 -v /tmp/.X11-unix:/tmp/.X11-unix -ti --name=dojo-gocd-yaml-config-plugin-2020-12-09_07-40-50-60121947 kudulab/openjdk-dojo:1.4.1 "gradle test jar"
 Unable to find image 'kudulab/openjdk-dojo:1.4.1' locally
@@ -198,7 +198,7 @@ Unable to find image 'alpine:3.21' locally
 root
 dojo@ebc220b9655f(inception-dojo):/dojo/work$ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-alpine              3.9                 78a2ce922f86        7 months ago        5.55MB
+alpine              3.21                 78a2ce922f86        7 months ago        5.55MB
 ```
 
 There is also an Alpine dind Docker image. Use it in the following way:
@@ -322,7 +322,7 @@ We have also established several **best practices** for dojo image development:
 Dojo provides [several scripts](image_scripts/src) to be used inside dojo images to meet most of above requirements. Scripts can be installed in a `Dockerfile` with:
 
 ```dockerfile
-ENV DOJO_VERSION=0.10.5
+ENV DOJO_VERSION=0.13.1
 RUN git clone --depth 1 -b ${DOJO_VERSION} https://github.com/kudulab/dojo.git /tmp/dojo_git &&\
   /tmp/dojo_git/image_scripts/src/install.sh && \
   rm -r /tmp/dojo_git
@@ -352,7 +352,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 # Install common Dojo scripts
-ENV DOJO_VERSION=0.10.5
+ENV DOJO_VERSION=0.13.1
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo git ca-certificates && \
@@ -397,10 +397,10 @@ cd "${dojo_work}"
 For alpine images a typical dockerfile has following structure:
 
 ```dockerfile
-FROM alpine:3.15
+FROM alpine:3.21
 
 # Install common Dojo scripts
-ENV DOJO_VERSION=0.10.5
+ENV DOJO_VERSION=0.13.1
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
   apk add --no-cache tini bash shadow sudo git && \
   git clone --depth 1 -b ${DOJO_VERSION} https://github.com/kudulab/dojo.git /tmp/dojo_git &&\
@@ -663,7 +663,6 @@ DOJO_DOCKER_COMPOSE_FILE="docker-compose.yml"
 Next to the `Dojofile`, you must create a docker-compose.yml according the [official reference](https://docs.docker.com/compose/compose-file/).
 Example docker-compose file:
 ```yaml
-version: '2.2'
 services:
   default:
     links:
@@ -684,7 +683,7 @@ You can try creating above 2 files in any directory and run `dojo`. The output s
 
 ```console
 tomzo@073c1c477b1f:/tmp/compose-example$ dojo
-2019/04/28 18:38:17 [ 1]  INFO: (main.main) Dojo version 0.3.2
+2019/04/28 18:38:17 [ 1]  INFO: (main.main) Dojo version 0.13.1
 2019/04/28 18:38:18 [20]  INFO: (main.DockerComposeDriver.HandleRun) docker-compose run command will be:
  docker-compose -f docker-compose.yml -f docker-compose.yml.dojo -p dojo-compose-example-2019-04-28_18-38-17-33362956 run --rm default
 Creating network "dojo-compose-example-2019-04-28_18-38-17-33362956_default" with the default driver
@@ -972,7 +971,7 @@ $ dojo -c Dojofile.build
 
 4. Run end to end tests:
 ```
-./tasks e2e ubuntu18
+./tasks e2e ubuntu
 ./tasks e2e alpine
 ```
 
@@ -996,7 +995,7 @@ $ dojo -c Dojofile.build
 
 ## License
 
-Copyright 2019-2022 Ava Czechowska, Tom Setkowski
+Copyright 2019-2025 Ava Czechowska, Tom Setkowski
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Docker version 19.03.5, build 633a0ea838
 $ docker info | grep "Server Version"
  Server Version: 19.03.5
 
-$ docker run --rm alpine:3.15 whoami
-Unable to find image 'alpine:3.15' locally
+$ docker run --rm alpine:3.21 whoami
+Unable to find image 'alpine:3.21' locally
 # pulling image messages
 root
 dojo@ebc220b9655f(inception-dojo):/dojo/work$ docker images
@@ -216,7 +216,7 @@ You can use Dojo with any Docker image, it does not have to be a Dojo Docker ima
 ```
 $ nano Dojofile
 $ cat Dojofile
-DOJO_DOCKER_IMAGE="alpine:3.16"
+DOJO_DOCKER_IMAGE="alpine:3.21"
 $ dojo
 # now we run interactively in the Dojo Docker container
 / # whoami
@@ -750,7 +750,7 @@ Usage of dojo <flags> [--] <CMD>:
   -identity-dir-outer string
     	Directory on host, to be mounted into a docker container to /dojo/identity. Default: $HOME
   -image string
-    	Docker image name and tag, e.g. alpine:3.15
+    	Docker image name and tag, e.g. alpine:3.21
   -interactive string
     	Set to false if you want to force not interactive docker run
   -ll string
@@ -818,15 +818,15 @@ is printed, press Ctrl+C. You may also test pressing Ctrl+C more times.
 
 1. driver: docker, container's PID 1 process **not** preserving signals:
 ```
-dojo --image=alpine:3.15 -i=false sh -c "echo 'will sleep' && sleep 1d"
+dojo --image=alpine:3.21 -i=false sh -c "echo 'will sleep' && sleep 1d"
 ```
 2. driver: docker, container's PID 1 process preserving signals:
 ```
-dojo --docker-options="--init" --image=alpine:3.15 -i=false sh -c "echo 'will sleep' && sleep 1d"
+dojo --docker-options="--init" --image=alpine:3.21 -i=false sh -c "echo 'will sleep' && sleep 1d"
 ```
 3. driver: docker-compose:
 ```
-dojo --driver=docker-compose --dcf=./test/test-files/itest-dc.yaml -i=false --image=alpine:3.15 sh -c "echo 'will sleep' && sleep 1d"
+dojo --driver=docker-compose --dcf=./test/test-files/itest-dc.yaml -i=false --image=alpine:3.21 sh -c "echo 'will sleep' && sleep 1d"
 ```
 
 ### Preserving exported Bash functions [#17](https://github.com/kudulab/dojo/issues/17)

--- a/config.go
+++ b/config.go
@@ -91,7 +91,7 @@ func getCLIConfig() Config {
 	flagSet.StringVar(&driver, "d", "", usageDriver+" (shorthand)")
 
 	var image string
-	const usageImage = "Docker image name and tag, e.g. alpine:3.15"
+	const usageImage = "Docker image name and tag, e.g. alpine:3.21"
 	flagSet.StringVar(&image, "image", "", usageImage)
 
 	var logLevel string

--- a/docker_compose_driver.go
+++ b/docker_compose_driver.go
@@ -707,24 +707,24 @@ func (dc DockerComposeDriver) getDCContainersNames(mergedConfig Config, projectN
 }
 
 type DC2PSOutput struct {
-	Command    string `json:"Command"`
-	CreatedAt  string `json:"CreatedAt"`
-	ExitCode   int    `json:"ExitCode"`
-	Health     string `json:"Health"`
-	ID         string `json:"ID"`
-	Image      string `json:"Image"`
-	Labels     string `json:"Labels"`
-	Name       string `json:"Name"`
-	Names      string `json:"Names"`
-	Networks   string `json:"Networks"`
-	Ports      string `json:"Ports"`
-	Project    string `json:"Project"`
-	Publishers string `json:"Publishers"`
-	RunningFor string `json:"RunningFor"`
-	Service    string `json:"Service"`
-	Size       string `json:"Size"`
-	State      string `json:"State"`
-	Status     string `json:"Status"`
+	Command    string   `json:"Command"`
+	CreatedAt  string   `json:"CreatedAt"`
+	ExitCode   int      `json:"ExitCode"`
+	Health     string   `json:"Health"`
+	ID         string   `json:"ID"`
+	Image      string   `json:"Image"`
+	Labels     string   `json:"Labels"`
+	Name       string   `json:"Name"`
+	Names      string   `json:"Names"`
+	Networks   string   `json:"Networks"`
+	Ports      string   `json:"Ports"`
+	Project    string   `json:"Project"`
+	Publishers []string `json:"Publishers"`
+	RunningFor string   `json:"RunningFor"`
+	Service    string   `json:"Service"`
+	Size       string   `json:"Size"`
+	State      string   `json:"State"`
+	Status     string   `json:"Status"`
 }
 
 // Parses the output of the `docker-compose ps --format json --all` command, into json.
@@ -734,6 +734,9 @@ type DC2PSOutput struct {
 // {"Command":"\"/bin/sh -c 'while t…\"","CreatedAt":"2024-02-03 21:03:46 +0000 UTC","ExitCode":0,"Health":"","ID":"2d5c5b0343d0","Image":"alpine:3.19","Labels":"com.docker.compose.depends_on=,com.docker.compose.image=sha256:05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd,com.docker.compose.version=2.24.5,com.docker.compose.service=abc,com.docker.compose.config-hash=270e27422cb1e6a4c1713ae22a3ffca0e8aa50ec0f06fe493fa4f83a17bd29e9,com.docker.compose.container-number=1,com.docker.compose.oneoff=False,com.docker.compose.project=testdojorunid,com.docker.compose.project.config_files=/dojo/work/test/test-files/itest-dc.yaml,/dojo/work/test/test-files/itest-dc.yaml.dojo,com.docker.compose.project.working_dir=/dojo/work/test/test-files","LocalVolumes":"0","Mounts":"/tmp/test-dojo…,/tmp/test-dojo…","Name":"testdojorunid-abc-1","Names":"testdojorunid-abc-1","Networks":"testdojorunid_default","Ports":"","Project":"testdojorunid","Publishers":null,"RunningFor":"3 seconds ago","Service":"abc","Size":"0B","State":"running","Status":"Up 2 seconds"}
 // {"Command":"\"/bin/sh -c 'while t…\"","CreatedAt":"2024-02-03 21:03:46 +0000 UTC","ExitCode":0,"Health":"","ID":"b2ed210567c3","Image":"alpine:3.19","Labels":"com.docker.compose.project=testdojorunid,com.docker.compose.project.config_files=/dojo/work/test/test-files/itest-dc.yaml,/dojo/work/test/test-files/itest-dc.yaml.dojo,com.docker.compose.project.working_dir=/dojo/work/test/test-files,com.docker.compose.depends_on=,com.docker.compose.container-number=1,com.docker.compose.image=sha256:05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd,com.docker.compose.oneoff=False,com.docker.compose.service=def,com.docker.compose.version=2.24.5,com.docker.compose.config-hash=270e27422cb1e6a4c1713ae22a3ffca0e8aa50ec0f06fe493fa4f83a17bd29e9","LocalVolumes":"0","Mounts":"/tmp/test-dojo…,/tmp/test-dojo…","Name":"testdojorunid-def-1","Names":"testdojorunid-def-1","Networks":"testdojorunid_default","Ports":"","Project":"testdojorunid","Publishers":null,"RunningFor":"3 seconds ago","Service":"def","Size":"0B","State":"running","Status":"Up 2 seconds"}
 // {"Command":"\"sh -c 'sleep 10'\"","CreatedAt":"2024-02-03 21:03:47 +0000 UTC","ExitCode":0,"Health":"","ID":"af4817fede41","Image":"alpine:3.15","Labels":"com.docker.compose.version=2.24.5,com.docker.compose.container-number=1,com.docker.compose.depends_on=abc:service_started:true,def:service_started:true,com.docker.compose.oneoff=True,com.docker.compose.project=testdojorunid,com.docker.compose.slug=742bcbb0e4bc05b21928a8d17be4ea9bb12a6775fd40692dd59c74a460279eb8,com.docker.compose.config-hash=462afacb4521d13580c2096c7b00b98970f07fe841e408c4c5a95a4a46839eaa,com.docker.compose.image=sha256:32b91e3161c8fc2e3baf2732a594305ca5093c82ff4e0c9f6ebbd2a879468e1d,com.docker.compose.project.config_files=/dojo/work/test/test-files/itest-dc.yaml,/dojo/work/test/test-files/itest-dc.yaml.dojo,com.docker.compose.project.working_dir=/dojo/work/test/test-files,com.docker.compose.service=default","LocalVolumes":"0","Mounts":"/home/dojo,/dojo/work,/tmp/test-dojo…,/tmp/test-dojo…,/tmp/.X11-unix,/tmp/dojo-ites…","Name":"testdojorunid-default-run-742bcbb0e4bc","Names":"testdojorunid-default-run-742bcbb0e4bc","Networks":"testdojorunid_default","Ports":"","Project":"testdojorunid","Publishers":null,"RunningFor":"2 seconds ago","Service":"default","Size":"0B","State":"running","Status":"Up 1 second"}
+//
+// when using docker-compose: 2.31m the field with Publishers is set to []:
+// {"Command":"\"/bin/sh -c 'while t…\"","CreatedAt":"2024-12-20 15:58:00 +1300 NZDT","ExitCode":143,"Health":"","ID":"f543828473a7","Image":"alpine:3.19","Labels":"com.docker.compose.image=sha256:7a85bf5dc56c949be827f84f9185161265c58f589bb8b2a6b6bb6d3076c1be21,desktop.docker.io/binds/0/Source=/tmp/dojo-environment-multiline-dojo-test-files-2024-12-2015-58-00-6660523964295751458,desktop.docker.io/binds/0/SourceKind=hostFile,desktop.docker.io/binds/0/Target=/etc/dojo.d/variables/00-multiline-vars.sh,desktop.docker.io/binds/1/Target=/etc/dojo.d/variables/01-bash-functions.sh,com.docker.compose.oneoff=False,com.docker.compose.project.config_files=/Users/ava.czechowska/code/dojo/test/test-files/itest-dc.yaml,/Users/ava.czechowska/code/dojo/test/test-files/itest-dc.yaml.dojo,com.docker.compose.service=abc,desktop.docker.io/binds/1/SourceKind=hostFile,com.docker.compose.container-number=1,com.docker.compose.project.working_dir=/Users/ava.czechowska/code/dojo/test/test-files,com.docker.compose.config-hash=4439e404114c9d0f183d756084f3e0e80c56b731e1f1e14e6db1844134294969,com.docker.compose.depends_on=,com.docker.compose.project=dojo-test-files-2024-12-2015-58-00-6660523964295751458,com.docker.compose.version=2.31.0,desktop.docker.io/binds/1/Source=/tmp/dojo-environment-bash-functions-dojo-test-files-2024-12-2015-58-00-6660523964295751458","LocalVolumes":"0","Mounts":"/host_mnt/priv…,/host_mnt/priv…","Name":"dojo-test-files-2024-12-2015-58-00-6660523964295751458-abc-1","Names":"dojo-test-files-2024-12-2015-58-00-6660523964295751458-abc-1","Networks":"dojo-test-files-2024-12-2015-58-00-6660523964295751458_default","Ports":"","Project":"dojo-test-files-2024-12-2015-58-00-6660523964295751458","Publishers":[],"RunningFor":"36 seconds ago","Service":"abc","Size":"0B","State":"exited","Status":"Exited (143) 10 seconds ago"}
 func ParseDCPSOutPut_DCVersion2(output string) ([]DC2PSOutput, string) {
 	var output_as_jsons []DC2PSOutput
 
@@ -746,7 +749,7 @@ func ParseDCPSOutPut_DCVersion2(output string) ([]DC2PSOutput, string) {
 		err := json.Unmarshal([]byte(line), &one_output_as_json)
 		if err != nil {
 			return []DC2PSOutput{},
-				fmt.Errorf("Error when decoding the JSON response from docker-compose ps command: %s", err).Error()
+				fmt.Errorf("Error when decoding the JSON response from docker-compose ps command: %s; line %s", err, line).Error()
 		}
 		if one_output_as_json.State == "" {
 			// This means that something went wrong, e.g. docker-compose ps output is now different

--- a/docker_compose_driver_test.go
+++ b/docker_compose_driver_test.go
@@ -17,7 +17,7 @@ func Test_parseDCFileVersion(t *testing.T) {
 	mytestsObj := []mytests{
 		mytests{"version: '4.55'", 4.55, ""},
 		mytests{"version: \"4.55\"", 4.55, ""},
-		mytests{"", 0, "First line of docker-compose file did not start with: version"},
+		mytests{"", -1, ""},
 	}
 	logger := NewLogger("debug")
 	dc := NewDockerComposeDriver(NewMockedShellServiceNotInteractive(logger), NewMockedFileService(logger), logger, "")

--- a/image_scripts/DockerfileAlpine
+++ b/image_scripts/DockerfileAlpine
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.21
 
 # For Dojo:
 # * entrypoint requires sudo and bash

--- a/image_scripts/DockerfileUbuntu
+++ b/image_scripts/DockerfileUbuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 
 # the Dojo scripts create a user with ID==1000,
 # previous ubuntu images (e.g. 20.04) seem to not have the ubuntu user,

--- a/image_scripts/README.md
+++ b/image_scripts/README.md
@@ -47,7 +47,7 @@ The `src/install.sh` script:
 ## Development
 Build and test Dojo docker images:
 ```
-cd dojo_image_scripts
+cd image_scripts
 ./tasks build
 ./tasks test_scripts
 ./tasks e2e

--- a/test/signal/signals-tests.sh
+++ b/test/signal/signals-tests.sh
@@ -118,7 +118,7 @@ set -x; rm -f "${test_file}"; touch "${test_file}"; set +x;
 
 wait_for_the_docker_daemon_to_be_running
 this_test_exit_status=0
-run_test_process_and_send_signal "./bin/dojo --debug=true --test=true --image=alpine:3.19 -i=false sh -c \"echo 'will sleep' && sleep 1d\"" "will sleep"
+run_test_process_and_send_signal "./bin/dojo --debug=true --test=true --image=alpine:3.21 -i=false sh -c \"echo 'will sleep' && sleep 1d\"" "will sleep"
 
 ## Test checks
 log_test "----------------------------------------------------------"

--- a/test/test-files/DirWithUpperCaseLetters/itest-dc.yaml
+++ b/test/test-files/DirWithUpperCaseLetters/itest-dc.yaml
@@ -14,7 +14,7 @@ services:
       ABC_DEF: "1234"
   abc:
     init: true
-    image: alpine:3.19
+    image: alpine:3.21
     entrypoint: ["/bin/sh", "-c"]
     # short-running command
     # command: ["true"]

--- a/test/test-files/itest-dc-env-var.yaml
+++ b/test/test-files/itest-dc-env-var.yaml
@@ -13,7 +13,7 @@ services:
       ABC_DEF: "1234"
   abc:
     init: true
-    image: alpine:3.15
+    image: alpine:3.21
     entrypoint: ["/bin/sh", "-c"]
     # short-running command
     # command: ["true"]

--- a/test/test-files/itest-dc-env-var.yaml
+++ b/test/test-files/itest-dc-env-var.yaml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
   default:
     # this option is needed to make default docker container preserve signals,

--- a/test/test-files/itest-dc-verbose-fail.yaml
+++ b/test/test-files/itest-dc-verbose-fail.yaml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
   default:
     # this option is needed to make default docker container preserve signals,

--- a/test/test-files/itest-dc-verbose-fail.yaml
+++ b/test/test-files/itest-dc-verbose-fail.yaml
@@ -13,6 +13,6 @@ services:
       ABC_DEF: "1234"
   abc:
     init: true
-    image: alpine:3.15
+    image: alpine:3.21
     entrypoint: ["/bin/sh", "-c"]
     command: ["some-non-existent-command"]

--- a/test/test-files/itest-dc-verbose.yaml
+++ b/test/test-files/itest-dc-verbose.yaml
@@ -13,7 +13,7 @@ services:
       ABC_DEF: "1234"
   abc:
     init: true
-    image: alpine:3.15
+    image: alpine:3.21
     entrypoint: ["/bin/sh", "-c"]
     # (double dolar sign is to escape the single dolar sign: https://stackoverflow.com/a/40621373/4457564)
     command: ["i=0; while true; do i=$$((i+1)); echo iteration: $$i; sleep 1; done;"]

--- a/test/test-files/itest-dc-verbose.yaml
+++ b/test/test-files/itest-dc-verbose.yaml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
   default:
     # this option is needed to make default docker container preserve signals,

--- a/test/test-files/itest-dc.yaml
+++ b/test/test-files/itest-dc.yaml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
   default:
     # this option is needed to make default docker container preserve signals,

--- a/test/test-files/itest-dc.yaml
+++ b/test/test-files/itest-dc.yaml
@@ -13,7 +13,7 @@ services:
       ABC_DEF: "1234"
   abc:
     init: true
-    image: alpine:3.19
+    image: alpine:3.21
     entrypoint: ["/bin/sh", "-c"]
     # short-running command
     # command: ["true"]

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -18,7 +18,7 @@ def test_help_output():
 
 def test_dojo_prints_error_if_bash_not_installed():
     dojo_exe = get_dojo_exe()
-    result = run_command('docker', ['run', '-t', '--rm', '-v', f"{dojo_exe}:/usr/bin/dojo", "alpine:3.19", "/usr/bin/dojo"])
+    result = run_command('docker', ['run', '-t', '--rm', '-v', f"{dojo_exe}:/usr/bin/dojo", "alpine:3.21", "/usr/bin/dojo"])
     combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Error while verifying if Bash is installed' in result.stdout, combined_output_str
     assert result.returncode == 1

--- a/test/test_docker.py
+++ b/test/test_docker.py
@@ -15,11 +15,11 @@ def test_docker_container_is_removed():
 
 def test_docker_when_zero_exit():
     clean_up_docker_container()
-    result = run_dojo('--debug=true --test=true --image=alpine:3.19 whoami'.split(' '))
+    result = run_dojo('--debug=true --test=true --image=alpine:3.21 whoami'.split(' '))
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'root' in result.stdout, dojo_combined_output_str
-    assert 'alpine:3.19 whoami' in result.stderr, dojo_combined_output_str
+    assert 'alpine:3.21 whoami' in result.stderr, dojo_combined_output_str
     assert 'Exit status from run command: 0' in result.stderr, dojo_combined_output_str
     assert 'Exit status from cleaning: 0' in result.stderr, dojo_combined_output_str
     assert 'Exit status from signals: 0' in result.stderr, dojo_combined_output_str
@@ -32,8 +32,8 @@ def test_docker_when_zero_exit():
 def test_docker_capture_output():
     clean_up_docker_container()
     # run this one test manually: pytest --capture=fd  --verbose test/test_docker.py::test_docker_capture_output
-    # run this without pytest: ./bin/dojo --debug=true --test=true --image=alpine:3.19 sh -c "printenv HOME"
-    result = run_dojo(['--debug=true', '--test=true', '--image=alpine:3.19', 'sh', '-c', "printenv HOME"])
+    # run this without pytest: ./bin/dojo --debug=true --test=true --image=alpine:3.21 sh -c "printenv HOME"
+    result = run_dojo(['--debug=true', '--test=true', '--image=alpine:3.21', 'sh', '-c', "printenv HOME"])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert '/root\n' == result.stdout, dojo_combined_output_str
@@ -49,7 +49,7 @@ def test_docker_capture_output():
 def test_docker_capture_output_when_unable_to_pull_image():
     clean_up_docker_container()
     # pytest --capture=fd  --verbose test/test_docker.py::test_docker_capture_output_when_unable_to_pull_image
-    # ./bin/dojo --debug=true --test=true --image=alpine:3.19 sh -c "printenv HOME && hostname"
+    # ./bin/dojo --debug=true --test=true --image=alpine:3.21 sh -c "printenv HOME && hostname"
     result = run_dojo(['--debug=true', '--test=true', '--image=no_such_image91291925129q783187314218194:abc111aaa.9981412', 'sh', '-c', "printenv HOME"])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -64,7 +64,7 @@ def test_docker_capture_output_when_unable_to_pull_image():
 
 def test_docker_when_non_existent_command():
     clean_up_docker_container()
-    result = run_dojo('--debug=true --test=true --image=alpine:3.19 notexistentcommand'.split(' '))
+    result = run_dojo('--debug=true --test=true --image=alpine:3.21 notexistentcommand'.split(' '))
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'executable file not found' in result.stderr, dojo_combined_output_str
@@ -76,7 +76,7 @@ def test_docker_when_non_existent_command():
 
 def test_docker_when_no_command():
     clean_up_docker_container()
-    result = run_dojo('--debug=true --test=true --image=alpine:3.19 -i=false'.split(' '))
+    result = run_dojo('--debug=true --test=true --image=alpine:3.21 -i=false'.split(' '))
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'Exit status from run command: 0' in result.stderr, dojo_combined_output_str
@@ -90,11 +90,11 @@ def test_docker_when_no_command():
 
 def test_docker_when_double_dash_command_split():
     clean_up_docker_container()
-    result = run_dojo('--debug=true --test=true --image=alpine:3.19 -- whoami'.split(' '))
+    result = run_dojo('--debug=true --test=true --image=alpine:3.21 -- whoami'.split(' '))
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'root' in result.stdout, dojo_combined_output_str
-    assert 'alpine:3.19 whoami' in result.stderr, dojo_combined_output_str
+    assert 'alpine:3.21 whoami' in result.stderr, dojo_combined_output_str
     assert 'Exit status from run command: 0' in result.stderr, dojo_combined_output_str
     assert 'Exit status from cleaning: 0' in result.stderr, dojo_combined_output_str
     assert 'Exit status from signals: 0' in result.stderr, dojo_combined_output_str
@@ -106,7 +106,7 @@ def test_docker_when_double_dash_command_split():
 
 def test_docker_when_shell_command():
     clean_up_docker_container()
-    result = run_dojo(['--debug=true', '--test=true', '--image=alpine:3.19', 'sh', '-c', 'echo hello'])
+    result = run_dojo(['--debug=true', '--test=true', '--image=alpine:3.21', 'sh', '-c', 'echo hello'])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'hello' in result.stdout, dojo_combined_output_str
@@ -124,7 +124,7 @@ def test_docker_preserves_env_vars():
     envs = dict(os.environ)
     envs['ABC'] = 'custom_value'
     result = run_dojo(
-        ['--debug=true', '--test=true', '--image=alpine:3.19', 'sh', '-c', 'env | grep ABC'],
+        ['--debug=true', '--test=true', '--image=alpine:3.21', 'sh', '-c', 'env | grep ABC'],
         env=envs)
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -171,7 +171,7 @@ second line"""
         # We need to source the file: /etc/dojo.d/variables/01-bash-functions.sh
         # explicitly, because the alpine docker image is not a Dojo image, i.e.
         # it does not have the Dojo entrypoint.sh.
-        ['--debug=true', '--test=true', '--image=alpine:3.19', 'sh', '-c', '"source /etc/dojo.d/variables/00-multiline-vars.sh && env | grep -A 1 ABC"'],
+        ['--debug=true', '--test=true', '--image=alpine:3.21', 'sh', '-c', '"source /etc/dojo.d/variables/00-multiline-vars.sh && env | grep -A 1 ABC"'],
         env=envs)
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -199,7 +199,7 @@ def test_docker_preserves_bash_functions_from_env_vars():
         # Dojo entrypoint sources this file too, but then it runs sudo.
         # https://unix.stackexchange.com/questions/549140/why-doesnt-sudo-e-preserve-the-function-environment-variables-exported-by-ex
         # https://unix.stackexchange.com/a/233097
-        ['--debug=true', '--test=true', '--image=alpine:3.19', 'sh', '-c', '"apk add -U bash && bash -c \'source /etc/dojo.d/variables/01-bash-functions.sh && my_bash_func\'"'],
+        ['--debug=true', '--test=true', '--image=alpine:3.21', 'sh', '-c', '"apk add -U bash && bash -c \'source /etc/dojo.d/variables/01-bash-functions.sh && my_bash_func\'"'],
         env=envs)
     stdout_value_bytes, stderr_value_bytes = proc.communicate()
     stdout = stdout_value_bytes.decode("utf-8")
@@ -220,7 +220,7 @@ def test_docker_preserves_bash_functions_from_env_vars():
 
 def test_docker_when_custom_relative_directory():
     clean_up_docker_container()
-    result = run_dojo(['-c', 'test/test-files/Dojofile', '--debug=true', '--test=true', '--image=alpine:3.19', 'whoami'])
+    result = run_dojo(['-c', 'test/test-files/Dojofile', '--debug=true', '--test=true', '--image=alpine:3.21', 'whoami'])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'root' in result.stdout, dojo_combined_output_str
@@ -239,7 +239,7 @@ def test_docker_when_nonexistent_custom_relative_directory():
         os.removedirs(os.path.join(project_root, 'test/test-files/not-existent'))
     except FileNotFoundError:
         pass
-    result = run_dojo(['-c', 'test/test-files/Dojofile.work_not_exists', '--debug=true', '--test=true', '--image=alpine:3.19', 'whoami'])
+    result = run_dojo(['-c', 'test/test-files/Dojofile.work_not_exists', '--debug=true', '--test=true', '--image=alpine:3.21', 'whoami'])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'root' in result.stdout, dojo_combined_output_str
@@ -253,7 +253,7 @@ def test_docker_when_nonexistent_custom_relative_directory():
 
 
 def test_docker_pull_when_image_can_be_pulled():
-    result = run_dojo('--debug=true --action=pull --image=alpine:3.19'.split(' '))
+    result = run_dojo('--debug=true --action=pull --image=alpine:3.21'.split(' '))
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert "Dojo version" in result.stderr, dojo_combined_output_str
     assert "Pulling from library/alpine" in result.stdout, dojo_combined_output_str

--- a/test/test_docker_compose.py
+++ b/test/test_docker_compose.py
@@ -43,7 +43,7 @@ def test_docker_compose_run_when_exit_zero():
     clean_up_dc_containers()
     clean_up_dc_network()
     clean_up_dc_dojofile()
-    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.19 whoami".split(' '))
+    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.21 whoami".split(' '))
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert result.returncode == 0
@@ -61,7 +61,7 @@ def test_docker_compose_run_command_output_capture():
     clean_up_dc_containers()
     clean_up_dc_network()
     clean_up_dc_dojofile()
-    result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.19', 'sh', '-c', "printenv HOME"])
+    result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.21', 'sh', '-c', "printenv HOME"])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert result.stdout == '/root\n', dojo_combined_output_str
     assert "Exit status from run command: 0" in result.stderr, dojo_combined_output_str
@@ -74,7 +74,7 @@ def test_docker_compose_run_when_exit_non_zero():
     clean_up_dc_containers()
     clean_up_dc_network()
     clean_up_dc_dojofile()
-    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.19 notexistentcommand".split(' '))
+    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.21 notexistentcommand".split(' '))
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert "Current shell is interactive: false" in result.stderr, dojo_combined_output_str
@@ -90,7 +90,7 @@ def test_docker_compose_run_when_double_dash_command_split():
     clean_up_dc_containers()
     clean_up_dc_network()
     clean_up_dc_dojofile()
-    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.19 -- whoami".split())
+    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --test=true --image=alpine:3.21 -- whoami".split())
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert result.returncode == 0
@@ -108,7 +108,7 @@ def test_docker_compose_run_when_shell_command():
     clean_up_dc_containers()
     clean_up_dc_network()
     clean_up_dc_dojofile()
-    result = run_dojo(['--driver=docker-compose',  '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.19', 'sh', '-c', 'echo hello'])
+    result = run_dojo(['--driver=docker-compose',  '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.21', 'sh', '-c', 'echo hello'])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'Exit status from run command: 0' in result.stderr, dojo_combined_output_str
@@ -127,7 +127,7 @@ def test_docker_compose_run_preserves_env_vars():
     clean_up_dc_dojofile()
     envs = dict(os.environ)
     envs['ABC'] ='custom_value'
-    result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.19', 'sh', '-c', 'env | grep ABC'],
+    result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true', '--image=alpine:3.21', 'sh', '-c', 'env | grep ABC'],
                       env=envs)
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -148,7 +148,7 @@ def test_docker_compose_run_preserves_multiline_env_vars():
     envs['ABC'] = """first line
 second line"""
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true',
-        '--image=alpine:3.19', 'sh', '-c', '"source /etc/dojo.d/variables/00-multiline-vars.sh && env | grep -A 1 ABC"'],
+        '--image=alpine:3.21', 'sh', '-c', '"source /etc/dojo.d/variables/00-multiline-vars.sh && env | grep -A 1 ABC"'],
         env=envs)
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -172,7 +172,7 @@ def test_docker_compose_run_preserves_bash_functions():
     envs = dict(os.environ)
     proc = run_dojo_and_set_bash_func(
         ['--driver=docker-compose', '--dcf=./test/test-files/itest-dc.yaml', '--debug=true', '--test=true',
-                 '--image=alpine:3.19', 'sh', '-c',
+                 '--image=alpine:3.21', 'sh', '-c',
                  '"apk add -U bash && bash -c \'source /etc/dojo.d/variables/01-bash-functions.sh && my_bash_func\'"'],
         env=envs)
     stdout_value_bytes, stderr_value_bytes = proc.communicate()
@@ -194,7 +194,7 @@ def test_docker_compose_run_preserves_bash_functions():
 
 
 def test_docker_compose_pull():
-    result = run_dojo('--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --action=pull --image=alpine:3.19'.split(' '))
+    result = run_dojo('--driver=docker-compose --dcf=./test/test-files/itest-dc.yaml --debug=true --action=pull --image=alpine:3.21'.split(' '))
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert 'Pulling' in result.stderr, dojo_combined_output_str
@@ -221,7 +221,7 @@ def test_docker_compose_dojo_work_variables():
     with open(os.path.join(project_root, 'test/test-files/custom-dir-env-var/file1.txt'), 'w') as f:
         f.write('123')
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-env-var.yaml',
-                       '--debug=true', '--test=true', '--image=alpine:3.19', '--', 'sh',
+                       '--debug=true', '--test=true', '--image=alpine:3.21', '--', 'sh',
                        '-c', "cat /dojo/work/custom-dir/file1.txt"])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert "Dojo version" in result.stderr, dojo_combined_output_str
@@ -244,7 +244,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_all_containers
     # container is started and managed to produce some output
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-verbose.yaml',
                        '--print-logs=always',
-                       '--debug=true', '--test=true', '--image=alpine:3.19', '--', 'sh',
+                       '--debug=true', '--test=true', '--image=alpine:3.21', '--', 'sh',
                        '-c', "echo 1; sleep 1; echo 2; sleep 1;"])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -274,7 +274,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_all_containers
     # container is started and managed to produce some output
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-verbose.yaml',
                        '--print-logs=always',
-                       '--debug=true', '--test=true', '--image=alpine:3.19', '--', 'sh',
+                       '--debug=true', '--test=true', '--image=alpine:3.21', '--', 'sh',
                        '-c', "echo 1;"])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -299,7 +299,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_nondefault_con
     # container is started and managed to produce some output
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-verbose-fail.yaml',
                        '--print-logs=always',
-                       '--debug=true', '--test=true', '--image=alpine:3.19', '--', 'sh',
+                       '--debug=true', '--test=true', '--image=alpine:3.21', '--', 'sh',
                        '-c', "echo 1; sleep 1; echo 2; sleep 1;"])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -322,7 +322,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_default_contai
     clean_up_dc_dojofile()
     # make the command of the default container last long enough so that the other
     # container is started and managed to produce some output
-    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc-verbose.yaml --print-logs=failure --debug=true --test=true --image=alpine:3.19 -- some-non-existent-command".split())
+    result = run_dojo("--driver=docker-compose --dcf=./test/test-files/itest-dc-verbose.yaml --print-logs=failure --debug=true --test=true --image=alpine:3.21 -- some-non-existent-command".split())
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
     assert result.returncode == 127
@@ -357,7 +357,7 @@ def test_docker_compose_run_shows_nondefault_containers_logs_when_all_constainer
     # container is started and managed to produce some output
     result = run_dojo(['--driver=docker-compose', '--dcf=./test/test-files/itest-dc-verbose.yaml',
                        '--print-logs=always', '--print-logs-target=file',
-                       '--debug=false', '--test=true', '--image=alpine:3.19', '--', 'sh',
+                       '--debug=false', '--test=true', '--image=alpine:3.21', '--', 'sh',
                        '-c', "echo 1; sleep 1; echo 2; sleep 1;"])
     dojo_combined_output_str =  "stdout:\n{0}\nstderror:\n{1}".format(result.stdout, result.stderr)
     assert 'Dojo version' in result.stderr, dojo_combined_output_str
@@ -402,7 +402,7 @@ def test_docker_compose_run_in_directory_with_capital_letters():
 
     dojo_exe = os.path.join(test_dir, '..', '..', 'bin', 'dojo')
     dojo_exe_absolute_path = os.path.abspath(dojo_exe)
-    dojo_args = ['--driver=docker-compose', '--dcf=./itest-dc.yaml', '--debug=true', '--image=alpine:3.19', 'sh', '-c', "printenv HOME"]
+    dojo_args = ['--driver=docker-compose', '--dcf=./itest-dc.yaml', '--debug=true', '--image=alpine:3.21', 'sh', '-c', "printenv HOME"]
     result = subprocess.run([dojo_exe] + dojo_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False, cwd='test/test-files/DirWithUpperCaseLetters')
     result.stdout = decode_utf8(result.stdout)
     result.stderr = decode_utf8(result.stderr)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
-const DojoVersion = "0.13.0"
+const DojoVersion = "0.13.1"
 


### PR DESCRIPTION
* docker-compose: support it when there is no version statement in the top of the yaml file; tested with docker-compose v2.24.5 and v2.31.0
* docker-compose: fix json decoding on mac - the Publishers field was resulting in decoding errors
* bump dojo image scripts base images
  * alpine:3.21
  * ubuntu:24.10